### PR TITLE
[#120924207] Correctly plumb through hostname to container

### DIFF
--- a/cfn-docker
+++ b/cfn-docker
@@ -8,6 +8,7 @@ import docker
 import subprocess
 import json
 import urllib2
+import socket
 from tsort import topological_sort
 from threading import Thread
 import sys
@@ -181,10 +182,10 @@ def run_single(name, config, restart=False, forcePull=False):
 
             # The beforeStart environment is also has the normal container environment
             beforeStartEnvironment = dict(config['environment'].items() + beforeStart['environment'].items())
-            beforeStartEnvironment['HOST_HOSTNAME'] = os.environ["HOSTNAME"]
+            beforeStartEnvironment['HOST_HOSTNAME'] = socket.gethostname()
             container_name = "%s-pre" % (name)
 
-            docker_client.create_container(config['image'], name=container_name, environment=beforeStartEnvironment, command=beforeStart.get('command', None), hostname=os.environ["HOSTNAME"])
+            docker_client.create_container(config['image'], name=container_name, environment=beforeStartEnvironment, command=beforeStart.get('command', None), hostname=socket.gethostname())
             try:
                 docker_client.start(container_name, binds=config.get('volumes', None), port_bindings=config.get('ports', None), links=None)
                 exit_code = docker_client.wait(container_name)
@@ -203,9 +204,9 @@ def run_single(name, config, restart=False, forcePull=False):
         # Although this is currently also being pushed through as HOSTNAME in the container,
         # we want to stop doing that because it shadows the container id (which docker sets
         # to HOSTNAME by default)
-        environment['HOST_HOSTNAME'] = os.environ["HOSTNAME"]
+        environment['HOST_HOSTNAME'] = socket.gethostname()
 
-        docker_client.create_container(config['image'], name=name, environment=environment, command=config.get('command', None), hostname=os.environ["HOSTNAME"])
+        docker_client.create_container(config['image'], name=name, environment=environment, command=config.get('command', None), hostname=socket.gethostname())
 
     if not container_running(name):
         logger.info('Starting container %s' % (name))

--- a/cfn-docker
+++ b/cfn-docker
@@ -185,10 +185,12 @@ def run_single(name, config, restart=False, forcePull=False):
             container_name = "%s-pre" % (name)
 
             docker_client.create_container(config['image'], name=container_name, environment=beforeStartEnvironment, command=beforeStart.get('command', None), hostname=os.environ["HOSTNAME"])
-            docker_client.start(container_name, binds=config.get('volumes', None), port_bindings=config.get('ports', None), links=None)
-            exit_code = docker_client.wait(container_name)
-            logger.info(docker_client.logs(container_name))
-            docker_client.remove_container(container_name)
+            try:
+                docker_client.start(container_name, binds=config.get('volumes', None), port_bindings=config.get('ports', None), links=None)
+                exit_code = docker_client.wait(container_name)
+                logger.info(docker_client.logs(container_name))
+            finally:
+                docker_client.remove_container(container_name)
 
         logger.info('Creating container %s' % (name))
 


### PR DESCRIPTION
You can't rely on HOSTNAME being present in the environment - there are some contexts in which it is not - such as calling it via `/usr/bin/env`. 

I also made it clean up containers that it starts but fails to run - fixes some junk on CI.
